### PR TITLE
Remove dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-
-updates:
-  # Keep dependencies for GitHub Actions up-to-date
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: 'monthly'


### PR DESCRIPTION
Test runners are not ready, CI checks fail and have not been touched in 1.5 years